### PR TITLE
Remove reference to hard-coded splash screen in `app.js`

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { HomeScreen } from './screens/Home';
-import { SplashScreen } from './screens/Splash';
 import { IngredientScreen } from './screens/Ingredient';
 import { RecipeScreen } from './screens/Recipe';
 import { FilterScreen } from './screens/Filter';
@@ -18,12 +17,7 @@ const Stack = createNativeStackNavigator();
 function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName='Splash'>
-        <Stack.Screen
-          name='Splash'
-          component={SplashScreen}
-          options={{ headerShown: false }}
-        />
+      <Stack.Navigator initialRouteName='Home'>
         <Stack.Screen
           name='Home'
           component={HomeScreen}

--- a/components/RecipeList.jsx
+++ b/components/RecipeList.jsx
@@ -39,7 +39,7 @@ const RecipeList = ({ title, scrollEnabled, numberOfRecipes }) => {
   };
   return (
     <>
-      {recipes.length === 0 ? (
+      {recipes?.length === 0 ? (
         <View style={style.noRecipes}>
           <Text style={style.noRecipesText}>No recipes found.</Text>
         </View>


### PR DESCRIPTION
As discussed in our call, this fixed `recipesList.jsx` issue and ensures the `app.json` splash screen is launched first. 